### PR TITLE
Test viewmodel

### DIFF
--- a/feature-users/src/test/java/com/architecture/feature_users/list/UserViewModelTest.kt
+++ b/feature-users/src/test/java/com/architecture/feature_users/list/UserViewModelTest.kt
@@ -12,8 +12,9 @@ import java.nio.charset.StandardCharsets
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -27,42 +28,42 @@ class UserViewModelTest {
 
     private lateinit var userRepository: UserRepository
     private lateinit var viewModel: UserViewModel
-    private val testDispatcher = TestCoroutineDispatcher()
 
     @Before
     fun setUp() {
-        Dispatchers.setMain(testDispatcher)
+        Dispatchers.setMain(StandardTestDispatcher())
         userRepository = mock(UserRepository::class.java)
         viewModel = UserViewModel(userRepository)
     }
 
     @After
     fun tearDown() {
-        testDispatcher.cleanupTestCoroutines()
+        Dispatchers.resetMain()
     }
 
     @Test
-    fun `WHEN action Load is received THEN state contains list of users`() =
-        testDispatcher.runBlockingTest {
-            // Given
-            val userList = listOf(User("test@email.com", "Test User", "test_picture"))
-            `when`(userRepository.getUserList()).thenReturn(flowOf(DataState.Success(userList)))
+    fun `WHEN action Load is received THEN state contains list of users`() = runTest {
+        // Given
+        val userList = listOf(User("test@email.com", "Test User", "test_picture"))
+        `when`(userRepository.getUserList()).thenReturn(flowOf(DataState.Success(userList)))
 
+        viewModel.uiStateFlow.test {
             // When
-            viewModel.submitAction(UserUiAction.Load)
+            // The UserViewModel submit Load action in init block when it is instantiated
 
             // Then
-            viewModel.uiStateFlow.test {
-                // Assert Success state
-                assertEquals(UiState.Success(userList), expectMostRecentItem())
+            // Assert Loading state
+            assertEquals(UiState.Loading, awaitItem())
+            // Assert Success state
+            assertEquals(UiState.Success(userList), awaitItem())
 
-                // No more items should be emitted
-                expectNoEvents()
-            }
+            // No more items should be emitted
+            expectNoEvents()
         }
+    }
 
     @Test
-    fun `WHEN action Search is received THEN state contains list of match users`() = testDispatcher.runBlockingTest {
+    fun `WHEN action Search is received THEN state contains list of match users`() = runTest {
         // Given
         val userList = listOf(
             User("test1@email.com", "Test User 1", "test1_picture"),
@@ -70,64 +71,71 @@ class UserViewModelTest {
         )
         `when`(userRepository.getUserList()).thenReturn(flowOf(DataState.Success(userList)))
 
-        // When
-        viewModel.submitAction(UserUiAction.Load)
-        viewModel.submitAction(UserUiAction.Search("Test User 1"))
-
-        // Then
         viewModel.uiStateFlow.test {
-            assertEquals(UiState.Success(listOf(userList[0])), expectMostRecentItem())
+            // When
+            // The UserViewModel submit Load action in init block when it is instantiated
+            viewModel.submitAction(UserUiAction.Search("Test User 1"))
+
+            // Then
+            assertEquals(UiState.Loading, awaitItem())
+            assertEquals(UiState.Success(userList), awaitItem())
+            assertEquals(UiState.Success(listOf(userList[0])), awaitItem())
             expectNoEvents()
         }
     }
 
     @Test
-    fun `WHEN action Search is received THEN state contains empty list of users`() =
-        testDispatcher.runBlockingTest {
-            // Given
-            val userList = listOf(
-                User("test1@email.com", "Test User 1", "test1_picture"),
-                User("test2@email.com", "Test User 2", "test2_picture")
-            )
-            `when`(userRepository.getUserList()).thenReturn(flowOf(DataState.Success(userList)))
+    fun `WHEN action Search is received THEN state contains empty list of users`() = runTest {
+        // Given
+        val userList = listOf(
+            User("test1@email.com", "Test User 1", "test1_picture"),
+            User("test2@email.com", "Test User 2", "test2_picture")
+        )
+        `when`(userRepository.getUserList()).thenReturn(flowOf(DataState.Success(userList)))
 
+        viewModel.uiStateFlow.test {
             // When
-            viewModel.submitAction(UserUiAction.Load)
+            // The UserViewModel submit Load action in init block when it is instantiated
             viewModel.submitAction(UserUiAction.Search("Nonexistent User"))
 
             // Then
-            viewModel.uiStateFlow.test {
-                assertEquals(UiState.Success(emptyList<User>()), expectMostRecentItem())
-                expectNoEvents()
-            }
+            // skip loading and user list item events
+            skipItems(2)
+            assertEquals(UiState.Success(emptyList<User>()), awaitItem())
+            expectNoEvents()
         }
+    }
 
 
     @Test
-    fun `WHEN action UserClick is received THEN state contains OpenUserScreen single event`() =
-        testDispatcher.runBlockingTest {
-            // Given
-            val user = User("test@email.com", "Test User", "test_picture")
+    fun `WHEN action UserClick is received THEN state contains OpenUserScreen single event`() = runTest {
+        // Given
+        val userList = listOf(
+            User("test1@email.com", "Test User 1", "test1_picture"),
+            User("test2@email.com", "Test User 2", "test2_picture")
+        )
+        val user = userList[0]
+        `when`(userRepository.getUserList()).thenReturn(flowOf(DataState.Success(userList)))
 
+        viewModel.singleEventFlow.test {
             // When
             viewModel.submitAction(UserUiAction.UserClick(user))
 
             // Then
-            viewModel.singleEventFlow.test {
-                assertEquals(
-                    expectMostRecentItem(), UserListUiSingleEvent.OpenUserScreen(
-                        NavRoutes.User.routeForUser(
-                            UserInput(
-                                user.name,
-                                user.email,
-                                URLEncoder.encode(user.picture, StandardCharsets.UTF_8.toString())
-                            )
+            assertEquals(
+                awaitItem(), UserListUiSingleEvent.OpenUserScreen(
+                    NavRoutes.User.routeForUser(
+                        UserInput(
+                            user.name,
+                            user.email,
+                            URLEncoder.encode(user.picture, StandardCharsets.UTF_8.toString())
                         )
                     )
                 )
+            )
 
-                expectNoEvents()
-            }
+            expectNoEvents()
         }
+    }
 
 }

--- a/feature-users/src/test/java/com/architecture/feature_users/single/UserSingleViewModelTest.kt
+++ b/feature-users/src/test/java/com/architecture/feature_users/single/UserSingleViewModelTest.kt
@@ -1,0 +1,55 @@
+package com.architecture.feature_users.single
+
+import app.cash.turbine.test
+import com.architecture.core.model.User
+import com.architecture.core.state.UiState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+
+@ExperimentalCoroutinesApi
+class UserSingleViewModelTest {
+
+    private lateinit var viewModel: UserSingleViewModel
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher())
+        viewModel = UserSingleViewModel()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `WHEN action Load is received THEN state contains user details`() = runTest {
+        // Given
+        val userName = "Test User 1"
+        val email = "test1@email.com"
+        val picture = "test1_picture"
+
+        viewModel.uiStateFlow.test {
+            // When
+            viewModel.submitAction(UserSingleUiAction.Load(userName, email, picture))
+
+            // Then
+            assertEquals(UiState.Loading, awaitItem())
+            assertEquals(UiState.Success(User(email, userName, picture)), awaitItem())
+
+            // No more items should be emitted
+            expectNoEvents()
+        }
+
+    }
+
+}


### PR DESCRIPTION
## Description

Test the view model for the single user detail view.

Also, `TestCoroutineDispatcher` is replaced by `StandardTestDispatcher`. And `runBlocking `is replaced by `runTest`


## References
[Migration to the new kotlinx-coroutines-test API](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-test/MIGRATION.md)